### PR TITLE
Updating the backup file whenever a streaming update is processed by Ygg

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,28 @@ Dim unleash = New DefaultUnleash(unleashSettings)
 
 ```
 
+## Experimental: Streaming
+
+The default behaviour of the Unleash SDK is to use polling for updating the feature configuration. 
+Unleash is currently experimenting with enabling streaming updates via SSE. 
+If you're on a plan that supports it (one of our `Enterprise` offerings) you can reach out to customer success to have it enabled for your instance. 
+When streaming has been enabled for your instance, you can configure your SDK like this during startup:
+
+```csharp
+var settings = new UnleashSettings()
+{
+    AppName = "dotnet-test",
+    UnleashApi = new Uri("https://eu.app.unleash-hosted.com/demo/api/"),
+    CustomHttpHeaders = new Dictionary<string, string>()
+    {
+        {"Authorization", "API token" }
+    },
+    ExperimentalStreamingUri = new Uri("https://eu.app.unleash-hosted.com/demo/api/client/streaming")
+};
+```
+
+Note the setting of the `ExperimentalStreamingUri` settings property.
+
 ## Logging
 
 By default Unleash-client uses LibLog to integrate with the currently configured logger for your application.

--- a/README.md
+++ b/README.md
@@ -360,28 +360,6 @@ Dim unleash = New DefaultUnleash(unleashSettings)
 
 ```
 
-## Experimental: Streaming
-
-The default behaviour of the Unleash SDK is to use polling for updating the feature configuration. 
-Unleash is currently experimenting with enabling streaming updates via SSE. 
-If you're on a plan that supports it (one of our `Enterprise` offerings) you can reach out to customer success to have it enabled for your instance. 
-When streaming has been enabled for your instance, you can configure your SDK like this during startup:
-
-```csharp
-var settings = new UnleashSettings()
-{
-    AppName = "dotnet-test",
-    UnleashApi = new Uri("https://eu.app.unleash-hosted.com/demo/api/"),
-    CustomHttpHeaders = new Dictionary<string, string>()
-    {
-        {"Authorization", "API token" }
-    },
-    ExperimentalStreamingUri = new Uri("https://eu.app.unleash-hosted.com/demo/api/client/streaming")
-};
-```
-
-Note the setting of the `ExperimentalStreamingUri` settings property.
-
 ## Logging
 
 By default Unleash-client uses LibLog to integrate with the currently configured logger for your application.

--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -259,9 +259,10 @@ namespace Unleash.Communication
             StreamingFeatureFetcher streamingEventHandler
         )
         {
+            const string requestUri = "client/streaming";
             StreamingEventHandler = streamingEventHandler;
             EventSource = new EventSource(
-                Configuration.Builder(apiUri)
+                Configuration.Builder(new Uri(apiUri, requestUri))
                 .HttpRequestModifier((requestMessage) =>
                 {
                     SetRequestHeaders(requestMessage, clientRequestHeaders);

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -108,7 +108,7 @@ namespace Unleash
 
             var scheduledTasks = new List<IUnleashScheduledTask>(3);
 
-            if (settings.ExperimentalStreamingUri == null)
+            if (!settings.ExperimentalUseStreaming)
             {
                 var fetchFeatureTogglesTask = new FetchFeatureTogglesTask(
                     engine,

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -133,7 +133,9 @@ namespace Unleash
                     settings,
                     apiClient,
                     engine,
-                    eventConfig
+                    eventConfig,
+                    backupFile,
+                    settings.FileSystem
                 );
                 Task.Run(() => StreamingFeatureFetcher.StartAsync().ConfigureAwait(false));
             }

--- a/src/Unleash/Streaming/StreamingFeatureFetcher.cs
+++ b/src/Unleash/Streaming/StreamingFeatureFetcher.cs
@@ -37,7 +37,7 @@ namespace Unleash.Streaming
         {
             try
             {
-                await ApiClient.StartStreamingAsync(Settings.ExperimentalStreamingUri, this).ConfigureAwait(false);
+                await ApiClient.StartStreamingAsync(Settings.UnleashApi, this).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/Unleash/Streaming/StreamingFeatureFetcher.cs
+++ b/src/Unleash/Streaming/StreamingFeatureFetcher.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Unleash.Internal;
 using Unleash.Events;
 using Unleash.Logging;
+using System.IO;
 
 namespace Unleash.Streaming
 {
@@ -15,16 +16,20 @@ namespace Unleash.Streaming
     {
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(StreamingFeatureFetcher));
 
-        public StreamingFeatureFetcher(UnleashSettings settings, IUnleashApiClient apiClient, YggdrasilEngine engine, EventCallbackConfig eventConfig)
+        public StreamingFeatureFetcher(UnleashSettings settings, IUnleashApiClient apiClient, YggdrasilEngine engine, EventCallbackConfig eventConfig, string toggleFile, IFileSystem fileSystem)
         {
             Settings = settings;
             ApiClient = apiClient;
             Engine = engine;
             EventConfig = eventConfig;
+            ToggleFile = toggleFile;
+            FileSystem = fileSystem;
         }
 
         private YggdrasilEngine Engine { get; set; }
         private EventCallbackConfig EventConfig { get; set; }
+        private string ToggleFile { get; }
+        private IFileSystem FileSystem { get; }
         private UnleashSettings Settings { get; set; }
         private IUnleashApiClient ApiClient { get; set; }
 
@@ -61,10 +66,20 @@ namespace Unleash.Streaming
             try
             {
                 Engine.TakeState(data);
-                // TODO: implement backup storage
 
                 // now that the toggle collection has been updated, raise the toggles updated event if configured
                 EventConfig?.RaiseTogglesUpdated(new TogglesUpdatedEvent { UpdatedOn = DateTime.UtcNow });
+
+                try
+                {
+                    var state = Engine.GetState();
+                    FileSystem.WriteAllText(ToggleFile, state);
+                }
+                catch (IOException ex)
+                {
+                    Logger.Warn(() => $"UNLEASH: Exception when writing to toggle file '{ToggleFile}'.", ex);
+                    EventConfig?.RaiseError(new ErrorEvent() { ErrorType = ErrorType.TogglesBackup, Error = ex });
+                }
             }
             catch (Exception ex)
             {

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -130,9 +130,9 @@ namespace Unleash
         public bool BootstrapOverride { get; set; } = true;
 
         /// <summary>
-        /// EXPERIMENTAL: Gets or sets the uri to use with streaming
+        /// EXPERIMENTAL: Gets or sets if streaming should be used
         /// </summary>
-        public Uri ExperimentalStreamingUri { get; set; }
+        public bool ExperimentalUseStreaming { get; set; }
 
         /// <summary>
         /// INTERNAL: Gets or sets if the feature toggle fetch should be immeditely scheduled. Used by the client factory to prevent redundant initial fetches.

--- a/tests/Unleash.Tests/Streaming/StreamingFeatureFetcherTests.cs
+++ b/tests/Unleash.Tests/Streaming/StreamingFeatureFetcherTests.cs
@@ -68,10 +68,11 @@ public class StreamingFeatureFetcherTests
         var settings = new UnleashSettings
         {
             UnleashApiClient = apiClient,
+            UnleashApi = uri,
             AppName = "TestApp",
             InstanceTag = "TestInstance",
             ScheduledTaskManager = new MockedTaskManager(),
-            ExperimentalStreamingUri = uri,
+            ExperimentalUseStreaming = true,
         };
         var unleash = new DefaultUnleash(settings);
         var payload = "{\"events\":[{\"type\":\"hydration\",\"eventId\":1,\"features\":[{\"name\":\"deltaFeature\",\"enabled\":true,\"strategies\":[],\"variants\":[]}],\"segments\":[]}]}";
@@ -120,7 +121,7 @@ public class StreamingFeatureFetcherTests
             AppName = "TestApp",
             InstanceTag = "TestInstance",
             ScheduledTaskManager = new MockedTaskManager(),
-            ExperimentalStreamingUri = uri
+            ExperimentalUseStreaming = true,
         };
 
         // Act
@@ -182,7 +183,7 @@ public class StreamingFeatureFetcherTests
             AppName = "TestApp",
             InstanceTag = "TestInstance",
             ScheduledTaskManager = new MockedTaskManager(),
-            ExperimentalStreamingUri = uri
+            ExperimentalUseStreaming = true,
         };
 
         // Act
@@ -241,7 +242,7 @@ public class StreamingFeatureFetcherTests
             AppName = "TestApp",
             InstanceTag = "TestInstance",
             ScheduledTaskManager = new MockedTaskManager(),
-            ExperimentalStreamingUri = uri
+            ExperimentalUseStreaming = true,
         };
 
         // Act
@@ -265,6 +266,7 @@ public class StreamingFeatureFetcherTests
         Assert.IsTrue(enabled, "Feature should be enabled after handling the message.");
         Assert.NotNull(fileContent, "File content should not be null");
         Assert.IsTrue(fileContent.StartsWith('{'));
+        Assert.IsTrue(fileContent.IndexOf("deltaFeature") > -1, "Feature flag not present in engine state");
     }
 }
 

--- a/tests/Unleash.Tests/Streaming/StreamingFeatureFetcherTests.cs
+++ b/tests/Unleash.Tests/Streaming/StreamingFeatureFetcherTests.cs
@@ -258,9 +258,13 @@ public class StreamingFeatureFetcherTests
         timer.Stop();
 
         var enabled = unleash.IsEnabled("deltaFeature");
+        var backupPath = settings.GetFeatureToggleFilePath();
+        var fileContent = File.ReadAllText(backupPath);
 
         // Assert
         Assert.IsTrue(enabled, "Feature should be enabled after handling the message.");
+        Assert.NotNull(fileContent, "File content should not be null");
+        Assert.IsTrue(fileContent.StartsWith('{'));
     }
 }
 


### PR DESCRIPTION
Does a getstate from Ygg whenever a streaming update has been sent to take_state, and pipes that through to the backup file.
