### PR TITLE
chore: amend uris missing trailing slash before adding relative uri

### DIFF
--- a/src/Unleash/Streaming/StreamingFeatureFetcher.cs
+++ b/src/Unleash/Streaming/StreamingFeatureFetcher.cs
@@ -37,7 +37,12 @@ namespace Unleash.Streaming
         {
             try
             {
-                await ApiClient.StartStreamingAsync(Settings.UnleashApi, this).ConfigureAwait(false);
+                var uri = Settings.UnleashApi;
+                if (!uri.AbsolutePath.EndsWith("/"))
+                {
+                    uri = new Uri($"{uri.AbsoluteUri}/");
+                }
+                await ApiClient.StartStreamingAsync(uri, this).ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
fixes an issue where not adding a trailing / after .../api would cause api portion to be removed before merging with relative uri when using streaming