### PR TITLE
Chore/mock out filesystem

### DIFF
--- a/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
+++ b/src/Unleash/Utilities/ToggleBootstrapFileProvider.cs
@@ -1,4 +1,5 @@
-﻿using Unleash.Internal;
+﻿using System.IO;
+using Unleash.Internal;
 
 namespace Unleash.Utilities
 {
@@ -15,7 +16,14 @@ namespace Unleash.Utilities
 
         public string Read()
         {
-            return settings.FileSystem.ReadAllText(filePath);
+            try
+            {
+                return settings.FileSystem.ReadAllText(filePath);
+            }
+            catch (FileNotFoundException)
+            {
+                return string.Empty;
+            }
         }
     }
 }

--- a/tests/Unleash.Tests/Mock/MockFileSystem.cs
+++ b/tests/Unleash.Tests/Mock/MockFileSystem.cs
@@ -1,32 +1,70 @@
-﻿using System.IO;
+﻿using System.Text;
 using Unleash.Internal;
 
 namespace Unleash.Tests.Mock
 {
     class MockFileSystem : IFileSystem
     {
+        internal readonly Dictionary<string, string> _fileSystem = new();
+        public Encoding Encoding => Encoding.UTF8;
+
         public bool FileExists(string path)
         {
-            return true;
+            return _fileSystem.ContainsKey(path);
         }
 
         public Stream FileOpenRead(string path)
         {
-            return new MemoryStream();
+            if (_fileSystem.TryGetValue(path, out var content))
+            {
+                return new TrackingWriteStream(path, _fileSystem, Encoding.UTF8);
+            }
+            throw new FileNotFoundException();
         }
 
         public Stream FileOpenCreate(string path)
         {
-            return new MemoryStream();
+            return new TrackingWriteStream(path, _fileSystem, Encoding.UTF8);
         }
 
         public void WriteAllText(string path, string content)
         {
+            _fileSystem[path] = content;
         }
 
         public string ReadAllText(string path)
         {
-            return string.Empty;
+            if (!_fileSystem.TryGetValue(path, out var content))
+            {
+                throw new FileNotFoundException();
+            }
+            return content!;
+        }
+    }
+
+    class TrackingWriteStream : MemoryStream
+    {
+        private readonly string _path;
+        private readonly Dictionary<string, string> _fs;
+        private readonly Encoding _encoding;
+
+        public TrackingWriteStream(string path, Dictionary<string, string> fs, Encoding encoding)
+        {
+            _path = path;
+            _fs = fs;
+            _encoding = encoding;
+        }
+
+        public override void Flush()
+        {
+            Position = 0;
+            using (var reader = new StreamReader(this, _encoding, leaveOpen: true))
+            {
+                var content = reader.ReadToEnd();
+                _fs[_path] = content;
+            }
+
+            base.Flush();
         }
     }
 }

--- a/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
+++ b/tests/Unleash.Tests/Utilities/ToggleBootstrapFileProvider_Tests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System.Text;
 using Unleash.Internal;
+using Unleash.Tests.Mock;
 using Unleash.Utilities;
 
 namespace Unleash.Tests.Utilities
@@ -18,9 +19,8 @@ namespace Unleash.Tests.Utilities
         public void Returns_String_Empty_When_File_Does_Not_Exist()
         {
             // Arrange
-            var fileSystem = new FileSystem(Encoding.UTF8);
-            string toggleFileName = AppDataFile("unleash-repo-v1-missing.json");
-            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem });
+            string toggleFileName = "unleash-repo-v1-missing.json";
+            var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = new MockFileSystem() });
 
             // Act
             var emptyResult = toggleFileProvider.Read();
@@ -33,10 +33,12 @@ namespace Unleash.Tests.Utilities
         public void Returns_File_Content_When_File_Exists()
         {
             // Arrange
-            var fileSystem = new FileSystem(Encoding.UTF8);
-            string toggleFileName = AppDataFile("unleash-repo-v1.json");
+            var fileSystem = new MockFileSystem();
+            string toggleFileName = "unleash-repo-v1.json";
+            string fileContent = "{ \"toggles\": [] }";
+
+            fileSystem.WriteAllText(toggleFileName, fileContent);
             var toggleFileProvider = new ToggleBootstrapFileProvider(toggleFileName, new UnleashSettings() { FileSystem = fileSystem });
-            var fileContent = fileSystem.ReadAllText(toggleFileName);
 
             // Act
             var result = toggleFileProvider.Read();
@@ -50,12 +52,13 @@ namespace Unleash.Tests.Utilities
         {
             // Arrange
             var settings = new UnleashSettings();
-            var toggleFileName = AppDataFile("unleash-repo-v1.json");
-            settings.UseBootstrapFileProvider(toggleFileName);
-            var fileSystem = new FileSystem(Encoding.UTF8);
-            settings.FileSystem = fileSystem;
+            var toggleFileName = "unleash-repo-v1.json";
+            var fileContent = "{ \"toggles\": [] }";
+            var fileSystem = new MockFileSystem();
+            fileSystem.WriteAllText(toggleFileName, fileContent);
 
-            var fileContent = fileSystem.ReadAllText(toggleFileName);
+            settings.UseBootstrapFileProvider(toggleFileName);
+            settings.FileSystem = fileSystem;
 
             // Act
             var result = settings.ToggleBootstrapProvider.Read();


### PR DESCRIPTION
Patches the mock file system to behave more realistically, use that in some tests

There's also a behaviour change when loading bootstrap. The test says that should return an empty string when the file isn't found but there's no actual check for a missing file so presumably this crashes with an exception in live. Not actually sure how this is passing, but presumably another test is putting an empty file on the file system