### PR TITLE
fix: dispose timers and fix disposal issues

### DIFF
--- a/src/Unleash/ClientFactory/UnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/UnleashClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Unleash.Strategies;
 
@@ -25,11 +26,19 @@ namespace Unleash.ClientFactory
                 settings.ScheduleFeatureToggleFetchImmediatly = false;
                 settings.ThrowOnInitialFetchFail = true;
                 var unleash = new DefaultUnleash(settings, strategies);
-                TaskFactory
-                    .StartNew(() => unleash.services.FetchFeatureTogglesTask.ExecuteAsync(CancellationToken.None))
-                    .Unwrap()
-                    .GetAwaiter()
-                    .GetResult();
+                try
+                {
+                    TaskFactory
+                        .StartNew(() => unleash.services.FetchFeatureTogglesTask.ExecuteAsync(CancellationToken.None))
+                        .Unwrap()
+                        .GetAwaiter()
+                        .GetResult();
+                }
+                catch (Exception ex)
+                {
+                    unleash.Dispose();
+                    throw ex;
+                }
 
                 return unleash;
             }
@@ -49,7 +58,15 @@ namespace Unleash.ClientFactory
                 settings.ScheduleFeatureToggleFetchImmediatly = false;
                 settings.ThrowOnInitialFetchFail = true;
                 var unleash = new DefaultUnleash(settings, strategies);
-                await unleash.services.FetchFeatureTogglesTask.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    await unleash.services.FetchFeatureTogglesTask.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    unleash.Dispose();
+                    throw ex;
+                }
                 return unleash;
             }
             return new DefaultUnleash(settings, strategies);

--- a/src/Unleash/ClientFactory/UnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/UnleashClientFactory.cs
@@ -65,7 +65,7 @@ namespace Unleash.ClientFactory
                 catch (Exception ex)
                 {
                     unleash.Dispose();
-                    throw ex;
+                    throw;
                 }
                 return unleash;
             }

--- a/src/Unleash/ClientFactory/UnleashClientFactory.cs
+++ b/src/Unleash/ClientFactory/UnleashClientFactory.cs
@@ -37,7 +37,7 @@ namespace Unleash.ClientFactory
                 catch (Exception ex)
                 {
                     unleash.Dispose();
-                    throw ex;
+                    throw;
                 }
 
                 return unleash;

--- a/src/Unleash/Internal/UnleashServices.cs
+++ b/src/Unleash/Internal/UnleashServices.cs
@@ -99,7 +99,7 @@ namespace Unleash
                 apiClient = settings.UnleashApiClient;
             }
 
-            scheduledTaskManager = settings.ScheduledTaskManager;
+            scheduledTaskManager = settings.ScheduledTaskManager ?? new SystemTimerScheduledTaskManager();
 
             IsMetricsDisabled = settings.SendMetricsInterval == null;
 
@@ -174,6 +174,10 @@ namespace Unleash
             }
 
             engine?.Dispose();
+            if (scheduledTaskManager != null && !(scheduledTaskManager is SystemTimerScheduledTaskManager))
+            {
+                Logger.Warn(() => $"UNLEASH: Disposing ScheduledTaskManager of type {scheduledTaskManager.GetType().Name}");
+            }
             scheduledTaskManager?.Dispose();
             StreamingFeatureFetcher?.Dispose();
         }

--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -92,20 +92,19 @@ namespace Unleash.Scheduling
         public void Dispose()
         {
             if (_disposed) return;
+
             _shuttingDown = true;
-
             var timeout = TimeSpan.FromSeconds(1);
+            var timerNames = new List<string>(timers.Keys.AsEnumerable());
 
-            var keys = new List<string>(timers.Keys.AsEnumerable());
-
-            foreach (var k in keys)
+            foreach (var name in timerNames)
             {
-                timers[k]?.Change(Timeout.Infinite, Timeout.Infinite);
+                timers[name]?.Change(Timeout.Infinite, Timeout.Infinite);
             }
 
-            foreach (var k in keys)
+            foreach (var name in timerNames)
             {
-                var t = timers[k];
+                var t = timers[name];
                 if (t is null) continue;
 
                 using (var done = new ManualResetEvent(false))
@@ -114,11 +113,8 @@ namespace Unleash.Scheduling
                     if (willSignal)
                     {
                         if (!done.WaitOne(timeout))
-                            throw new TimeoutException($"Timeout waiting for timer '{k}' to stop.");
+                            throw new TimeoutException($"Timeout waiting for timer '{name}' to stop.");
                     }
-
-                    timers.Remove(k);
-
                 }
             }
 

--- a/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
+++ b/src/Unleash/Scheduling/SystemTimerScheduledTaskManager.cs
@@ -33,7 +33,7 @@ namespace Unleash.Scheduling
             async void Callback(object state)
             {
                 if (_shuttingDown) return;
-                
+
                 try
                 {
                     if (!cancellationToken.IsCancellationRequested)
@@ -118,7 +118,7 @@ namespace Unleash.Scheduling
                     }
 
                     timers.Remove(k);
-                        
+
                 }
             }
 

--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -101,9 +101,10 @@ namespace Unleash
 
         /// <summary>
         /// Gets or sets the scheduled task manager used for syncing feature toggles and metrics with the backend in the background.
-        /// Default: An implementation based on System.Threading.Timers
+        /// If not set will provide an internal implementation based on System.Threading.Timers
         /// </summary>
-        public IUnleashScheduledTaskManager ScheduledTaskManager { get; set; } = new SystemTimerScheduledTaskManager();
+        [Obsolete("Will be removed in an upcoming major version", false)]
+        public IUnleashScheduledTaskManager ScheduledTaskManager { get; set; }
 
 
         /// <summary>

--- a/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
+++ b/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
@@ -44,7 +44,7 @@ namespace Unleash.Tests.ClientFactory
             unleash.IsEnabled("one-enabled", false)
                 .Should().BeTrue();
         }
-
+    
         [Test(Description = "Immediate initialization: Should bubble up errors")]
         public void ImmediateInitializationBubbleErrors()
         {
@@ -176,6 +176,30 @@ namespace Unleash.Tests.ClientFactory
                     }
                 });
             });
+        }
+
+        [Test]
+        public void Failing_Synchronous_Initialization_Can_Still_Create_New_Instance()
+        {
+            var settings = new UnleashSettings
+            {
+                AppName = "test-app-name",
+                UnleashApi = new Uri("http://localhost:33/does/not/exist/api"),
+                CustomHttpHeaders = new Dictionary<string, string>()
+                {
+                    { "Authorization", "Token" },
+                }
+            };
+
+            var factory = new UnleashClientFactory();
+            Assert.ThrowsAsync<UnleashException>(async () =>
+            {
+                var failingUnleashInit = await factory.CreateClientAsync(settings, synchronousInitialization: true);
+            });
+
+            var unleash = new DefaultUnleash(settings);
+            Assert.IsNotNull(unleash);
+            Assert.True(unleash.IsEnabled("some-toggle", true));
         }
 
         private IUnleash GetUnleash(HttpResponseMessage response)

--- a/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
+++ b/tests/Unleash.Tests/ClientFactory/SyncStartupUnitTest.cs
@@ -44,7 +44,7 @@ namespace Unleash.Tests.ClientFactory
             unleash.IsEnabled("one-enabled", false)
                 .Should().BeTrue();
         }
-    
+
         [Test(Description = "Immediate initialization: Should bubble up errors")]
         public void ImmediateInitializationBubbleErrors()
         {


### PR DESCRIPTION
This PR fixes the issue with setting up a new Unleash instance after failing a synchronized initialization where the timer collection would stay around after the error and prevent newing up new instances with the same unleash settings object.

This also fixes a cleanup issue where disposing timers could lead to errors